### PR TITLE
Show NFT image on final press and remove ConnectKit modal shadows

### DIFF
--- a/components/multi-step-reveal.tsx
+++ b/components/multi-step-reveal.tsx
@@ -23,10 +23,11 @@ export default function MultiStepReveal({ tokenId, address, unrevealedImageUrl, 
 
   // Get the appropriate image based on press count
   const getRevealImage = () => {
+    // On the final press, show the NFT image (hive/unrevealed)
+    if (pressCount === 2 && !showAnimation) return unrevealedImageUrl
     if (showAnimation) return "/images/reveal-animation.gif"
     if (pressCount === 0) return "/images/reveal-press1.png" // honeycomb only
     if (pressCount === 1) return "/images/reveal-press2.gif" // honey drip only
-    if (pressCount === 2) return unrevealedImageUrl // hive (bee silhouette)
     return "/images/reveal-press1.png"
   }
 
@@ -37,11 +38,8 @@ export default function MultiStepReveal({ tokenId, address, unrevealedImageUrl, 
       setPressCount(pressCount + 1)
       return
     }
-
-    // On third press, show animation and start the reveal process
+    // On third (final) press, show the NFT image, then trigger the reveal animation
     setShowAnimation(true)
-
-    // Wait a moment to show the animation before proceeding
     setTimeout(() => {
       startRevealProcess()
     }, 1500)

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -28,6 +28,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
     '--ck-modal-background': '#FFB949',
     '--ck-overlay-background': 'rgba(0, 0, 0, 0.7)',
     '--ck-modal-box-shadow': 'none',
+    '--ck-modal-shadow': 'none',
+    '--ck-overlay-box-shadow': 'none',
     '--ck-body-background': '#FFB949',
     '--ck-body-color': '#3A1F16',
     '--ck-body-color-muted': '#5a3a2f',


### PR DESCRIPTION
On the final press in the reveal flow, show the NFT's unrevealed image before triggering the reveal. Also, remove all modal shadows from ConnectKit for a cleaner look.